### PR TITLE
Increasing java heap size

### DIFF
--- a/orbdetpy/rpc/server.py
+++ b/orbdetpy/rpc/server.py
@@ -37,7 +37,7 @@ class RemoteServer:
                 return
 
         # Start server
-        cmdline = ["java", "-Xmx2G", "-jar", jarfile, str(cls.rpc_port), datadir]
+        cmdline = ["java", "-Xms16G -Xmx16G", "-jar", jarfile, str(cls.rpc_port), datadir]
         cls.rpc_server_proc = psutil.Popen(cmdline, stdout = DEVNULL,
                                            stderr = DEVNULL)
 


### PR DESCRIPTION
Attempting to improve orbdetpy performance for dense measurement spands (i.e. 1 GPS state per second) by increase the java heap size from 2GB to 16GB.